### PR TITLE
Always login to tignis.azurecr.io.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build and Push docker image
-        uses: tignis/docker-github-action@v1.1.0
+        uses: tignis/docker-github-action@v1.2.1
         with:
           images: |
             tignis.azurecr.io/tignis/docker_github_action

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,12 @@ runs:
         registry: ${{ inputs.acr-registry-url }}
         username: ${{ inputs.acr-username }}
         password: ${{ inputs.acr-password }}
+    - name: Login to tignis ACR
+      uses: docker/login-action@v1
+      with:
+        registry: 'tignis.azurecr.io'
+        username: ${{ inputs.acr-username }}
+        password: ${{ inputs.acr-password }}
     - name: Build and push
       id: docker_build
       uses: docker/build-push-action@v2


### PR DESCRIPTION
Some tignissas builds pull private tignis images, and so they
are required to login to both repositories. To solve this,
we will simply always log into tignis CR. This route was chosen
because github actions does not have any good mechanics to loop
over a list of repositories, and the docker login action also
does not accept a list. This change is also backwards compatible.