### PR TITLE
fix: disable generation of latest tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,8 @@ runs:
       with:
         # list of Docker images to use as base name for tags
         images: ${{ inputs.images }}
+        flavor: |
+          latest=false
         # generate Docker tags based on the following events/attributes
         tags: |
           type=sha,prefix=${{inputs.tag-prefix}}${{env.BRANCH_NAME}}-${{env.DATE}}-${{github.run_number}}-,enable=${{ !startsWith(github.event_name, 'release') }}


### PR DESCRIPTION
Latest tag is not something we use and its use is discouraged. Also, dependent jobs expect that this action only ever creates one tag per image, and creating latest as well as a named tag breaks that assumption.