### PR TITLE
feat: print built docker image to prs when complete

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Prefix to add to generated docker tag'
     required: false
     default: ''
+  GITHUB_TOKEN:
+    description: 'Github token of the repository (automatically created by Github)'
+    default: ${{ github.token }}
+    required: false
 outputs:
   tag: # id of output
     description: 'Tag used for the docker image'
@@ -103,3 +107,14 @@ runs:
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}
       shell: bash
+    - name: Comment latest docker image
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        # Use GitHub API to create a comment on the PR
+        PR_NUMBER=${{ github.event.pull_request.number }}
+        COMMENT='Docker image built: `${{ steps.meta.outputs.tags }}`'
+        GITHUB_TOKEN=${{ inputs.GITHUB_TOKEN }}
+        COMMENT_URL="https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
+
+        curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST $COMMENT_URL -d "{\"body\":\"${COMMENT}\"}"


### PR DESCRIPTION
Saves you from having to dig in the build logs to get a the docker image that was built. An example was seen here https://github.com/tignis/monitor-service/pull/45#issuecomment-2152817931