### PR TITLE
chore: bump github action versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
       shell: bash
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       with:
         # list of Docker images to use as base name for tags
         images: ${{ inputs.images }}
@@ -80,20 +80,20 @@ runs:
       with:
         endpoint: builders
     - name: Login to ACR
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ${{ inputs.acr-registry-url }}
         username: ${{ inputs.acr-username }}
         password: ${{ inputs.acr-password }}
     - name: Login to tignis ACR
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: 'tignis.azurecr.io'
         username: ${{ inputs.acr-username }}
         password: ${{ inputs.acr-password }}
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: ${{ inputs.docker-build-context }}
         push: ${{ inputs.push }}


### PR DESCRIPTION
Bumping the versions of external github actions. This is an attempt to address deprecation warnings about docker commands that don't appear to come from our action code.

Example:
```Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/```