### PR TITLE
feat: add reusable workflow for builds speed up

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -184,3 +184,10 @@ jobs:
           
           echo "tag=${FINAL_TAG}" >> $GITHUB_OUTPUT
           echo "Multi-arch manifest created: ${FINAL_TAG}"
+
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMENT="Multi-arch manifest created: ${FINAL_TAG}"
+          GITHUB_TOKEN=${{ secrets.GH_TOKEN }}
+          COMMENT_URL="https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
+
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST $COMMENT_URL -d "{\"body\":\"${COMMENT}\"}"

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,0 +1,186 @@
+name: 'Multi-Architecture Docker Build'
+on:
+  workflow_call:
+    inputs:
+      images:
+        description: 'Name of images to build'
+        required: true
+        type: string
+      acr-registry-url:
+        description: 'The url of the ACR registry to fetch credentials from'
+        required: false
+        type: string
+        default: 'tignis.azurecr.io'        
+      push:
+        description: 'Also push the image to the remote repository'
+        required: false
+        type: string
+        default: 'true'
+      docker-build-context:
+        description: 'Build context for docker'
+        required: false
+        type: string
+        default: '.'
+      dockerfile:
+        description: 'Name of the docker file to use'
+        required: false
+        type: string
+        default: 'Dockerfile'
+    secrets:
+      acr-username:
+        description: 'Username to use when logging into ACR'
+        required: true
+      acr-password:
+        description: 'Password to use when logging into ACR'
+        required: true
+      pip-extra-index-url:
+        description: 'The PIP_EXTRA_INDEX_URL for private pip packages'
+        required: true
+      GH_TOKEN:  # Renamed from GITHUB_TOKEN
+        description: 'GitHub token for API access'
+        required: true        
+    outputs:
+      tag:
+        description: 'Final tag used for the multi-architecture docker image'
+        value: ${{ jobs.docker-manifest.outputs.tag }}
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  docker-amd64:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.docker.outputs.tag }}
+      digest: ${{ steps.digest.outputs.digest }}
+      image: ${{ inputs.images }}
+      tag-prefix: amd64-
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Build and Push docker image (AMD64)
+        id: docker
+        uses: tignis/docker-github-action@v2.3.1
+        with:
+          images: ${{ inputs.images }}
+          acr-username: ${{ secrets.acr-username }}
+          acr-password: ${{ secrets.acr-password }}
+          acr-registry-url: ${{ inputs.acr-registry-url }}
+          pip-extra-index-url: ${{ secrets.pip-extra-index-url }}
+          push: ${{ inputs.push }}
+          docker-build-context: ${{ inputs.docker-build-context }}
+          dockerfile: ${{ inputs.dockerfile }}
+          platforms: 'linux/amd64'
+          tag-prefix: 'amd64-'
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          
+
+  docker-arm64:
+    runs-on: [self-hosted, linux, ARM64]
+    outputs:
+      tag: ${{ steps.docker.outputs.tag }}
+      digest: ${{ steps.digest.outputs.digest }}
+      tag-prefix: arm64-
+      image: ${{ inputs.images }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Build and Push docker image (ARM64)
+        id: docker
+        uses: tignis/docker-github-action@v2.3.1
+        with:
+          images: ${{ inputs.images }}
+          acr-username: ${{ secrets.acr-username }}
+          acr-password: ${{ secrets.acr-password }}
+          acr-registry-url: ${{ inputs.acr-registry-url }}
+          pip-extra-index-url: ${{ secrets.pip-extra-index-url }}
+          push: ${{ inputs.push }}
+          docker-build-context: ${{ inputs.docker-build-context }}
+          dockerfile: ${{ inputs.dockerfile }}
+          platforms: 'linux/arm64'
+          tag-prefix: 'arm64-'
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  docker-manifest:
+    needs: [docker-amd64, docker-arm64]
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.final.outputs.tag }}
+    steps:
+      - name: Login to ACR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.acr-registry-url }}
+          username: ${{ secrets.acr-username }}
+          password: ${{ secrets.acr-password }}
+    
+      - name: Extract clean tag
+        id: clean-tag
+        run: |
+          AMD64_TAG=${{ needs.docker-amd64.outputs.tag }}
+          CLEAN_TAG=${AMD64_TAG#*:amd64-}
+          echo "value=${CLEAN_TAG}" >> $GITHUB_OUTPUT
+    
+      - name: Get image digests instead of tags
+        id: digests
+        run: |
+          # Get the actual image digests for single-platform images
+          AMD64_MANIFEST=$(docker manifest inspect ${{ needs.docker-amd64.outputs.tag }} --verbose)
+          ARM64_MANIFEST=$(docker manifest inspect ${{ needs.docker-arm64.outputs.tag }} --verbose)
+          
+          # Extract the digest for the specific platform from manifest lists
+          AMD64_DIGEST=$(echo "$AMD64_MANIFEST" | jq -r '.[] | select(.Descriptor.platform.architecture=="amd64") | .Descriptor.digest')
+          ARM64_DIGEST=$(echo "$ARM64_MANIFEST" | jq -r '.[] | select(.Descriptor.platform.architecture=="arm64") | .Descriptor.digest')
+          
+          # If the above doesn't work (single platform images), get the manifest digest directly
+          if [ -z "$AMD64_DIGEST" ] || [ "$AMD64_DIGEST" = "null" ]; then
+            AMD64_DIGEST=$(docker manifest inspect ${{ needs.docker-amd64.outputs.tag }} | jq -r '.config.digest // .digest')
+          fi
+          
+          if [ -z "$ARM64_DIGEST" ] || [ "$ARM64_DIGEST" = "null" ]; then
+            ARM64_DIGEST=$(docker manifest inspect ${{ needs.docker-arm64.outputs.tag }} | jq -r '.config.digest // .digest')
+          fi
+          
+          echo "amd64-digest=${AMD64_DIGEST}" >> $GITHUB_OUTPUT
+          echo "arm64-digest=${ARM64_DIGEST}" >> $GITHUB_OUTPUT
+          
+          echo "AMD64 digest: ${AMD64_DIGEST}"
+          echo "ARM64 digest: ${ARM64_DIGEST}"
+    
+      - name: Create multi-arch manifest from digests
+        id: final
+        run: |
+          IMAGE=${{ inputs.images }}
+          CLEAN_TAG=${{ steps.clean-tag.outputs.value }}
+          FINAL_TAG="${IMAGE}:${CLEAN_TAG}"
+          
+          AMD64_DIGEST=${{ steps.digests.outputs.amd64-digest }}
+          ARM64_DIGEST=${{ steps.digests.outputs.arm64-digest }}
+          
+          # Enable experimental features
+          export DOCKER_CLI_EXPERIMENTAL=enabled
+          
+          echo "Creating manifest ${FINAL_TAG} from digests:"
+          echo "  AMD64: ${IMAGE}@${AMD64_DIGEST}"
+          echo "  ARM64: ${IMAGE}@${ARM64_DIGEST}"
+          
+          # Create manifest using digests instead of tags
+          docker manifest create ${FINAL_TAG} \
+            ${IMAGE}@${AMD64_DIGEST} \
+            ${IMAGE}@${ARM64_DIGEST}
+          
+          # Add architecture annotations using digests
+          docker manifest annotate ${FINAL_TAG} \
+            ${IMAGE}@${AMD64_DIGEST} --os linux --arch amd64
+          docker manifest annotate ${FINAL_TAG} \
+            ${IMAGE}@${ARM64_DIGEST} --os linux --arch arm64
+          
+          # Push the manifest
+          docker manifest push ${FINAL_TAG}
+          
+          echo "tag=${FINAL_TAG}" >> $GITHUB_OUTPUT
+          echo "Multi-arch manifest created: ${FINAL_TAG}"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # docker-github-action
-github action wrapping a typical docker build for a tignis app. This workflow assumes that you will
-tag images based on the git commit hash for pull requests and pushes to branches, and for releases
-it will use the semver tag of the release.
 
-Below is an example of how to use this action.
-```
+GitHub action wrapping a typical Docker build for a Tignis app. This workflow assumes that you will tag images based on the git commit hash for pull requests and pushes to branches, and for releases it will use the semver tag of the release.
+
+## Usage Options
+
+### Option 1: Single Action (Simple)
+
+Use the action directly for single-platform builds or when you don't need separate architecture builds:
+
+```yaml
 name: ci
 
 on:
@@ -22,44 +26,162 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build and Push docker image
-        uses: tignis/docker-github-action@v1.2.1
+        uses: tignis/docker-github-action@v2.3.1
         with:
           images: |
-            tignis.azurecr.io/tignis/docker_github_action
+            tignis.azurecr.io/tignis/my_app
           acr-username: ${{ secrets.AZURE_APP_ID_ACR }}
           acr-password: ${{ secrets.AZURE_PASSWORD_ACR }}
-          pip-extra-index-url: ${{secrets.PIP_EXTRA_INDEX_URL}}"
-
+          pip-extra-index-url: ${{ secrets.PIP_EXTRA_INDEX_URL }}
 ```
 
-## Input options
+### Option 2: Multi-Architecture Workflow (Recommended)
+
+Use the reusable workflow for multi-architecture builds with dedicated runners for each architecture:
+
+```yaml
+name: ci
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+      - 'dev'
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install package
+        env:
+          PIP_EXTRA_INDEX_URL: ${{ secrets.PIP_EXTRA_INDEX_URL }}
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install '.[testing]'
+      - name: Test with pytest
+        run: pytest
+
+  docker:
+    needs:
+      - build  # Optional: depend on tests passing first
+    uses: tignis/docker-github-action/.github/workflows/workflows.yaml@v2.3.1
+    with:
+      images: tignis.azurecr.io/tignis/my_app
+    secrets:
+      acr-username: ${{ secrets.AZURE_APP_ID_ACR }}
+      acr-password: ${{ secrets.AZURE_PASSWORD_ACR }}
+      pip-extra-index-url: ${{ secrets.PIP_EXTRA_INDEX_URL }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Multi-Architecture Workflow Features
+
+The reusable workflow (`workflows.yaml`) provides:
+
+- **Separate Architecture Builds**: AMD64 builds on GitHub-hosted runners, ARM64 builds on self-hosted runners
+- **Multi-Architecture Manifest**: Automatically creates a manifest list that supports both architectures
+- **Status Reporting**: Provides a unified status check for branch protection rules
+- **PR Comments**: Automatically comments on pull requests with the built image tag
+- **Build Summary**: Creates detailed build summaries in GitHub Actions
+
+### Workflow Jobs
+
+The multi-architecture workflow consists of:
+
+1. **docker-amd64**: Builds AMD64 image on `ubuntu-latest`
+2. **docker-arm64**: Builds ARM64 image on `[self-hosted, linux, ARM64]`
+3. **docker-manifest**: Creates multi-architecture manifest from individual builds
+4. **docker**: Summary job that reports overall build status
+
+### Required Secrets
+
+For the multi-architecture workflow, you need these repository secrets:
+
+- `AZURE_APP_ID_ACR`: Azure Container Registry username
+- `AZURE_PASSWORD_ACR`: Azure Container Registry password  
+- `PIP_EXTRA_INDEX_URL`: Private pip package index URL
+- `GITHUB_TOKEN`: Automatically provided by GitHub (no setup needed)
+
+## Input Options
+
+### Action Inputs (Option 1)
 
 `images`: A list of names to use to tag your image with. Should be a multiline string with each line containing a single name.
 
-`push`: Boolean to determine if the image should be pushed to the remote repoistory. Defaults to `true`.
+`push`: Boolean to determine if the image should be pushed to the remote repository. Defaults to `true`.
 
-`acr-username`: The username to use to login to acr. Fetch this value from a github secret.
+`acr-username`: The username to use to login to ACR. Fetch this value from a GitHub secret.
 
-`acr-password`: The password to use to login to acr. Fetch this value from a github secret.
+`acr-password`: The password to use to login to ACR. Fetch this value from a GitHub secret.
 
-`acr-registry-url`: The url of which repository to use in ACR. Default to `tignis.azurecr.io`.
+`acr-registry-url`: The URL of which repository to use in ACR. Defaults to `tignis.azurecr.io`.
 
-`pip-extra-index-url`: The extra index url for pip to fetch packages from our jfrog repository. Fetch this value from a secret.
+`pip-extra-index-url`: The extra index URL for pip to fetch packages from our JFrog repository. Fetch this value from a secret.
 
-`docker-build-context`: What directory to use as the build context for docker. Defaults to the current directory.
-**Note:** If changinge the build context, ensure that the `dockerfile` parameter described below is also adjusted to be prefixed
-with the build context. For example if you have `docker-build-context: ./tignis/app`,then you'll also likely set 
-`dockerfile: ./tignis/app/dockerfile` too.
+`docker-build-context`: What directory to use as the build context for Docker. Defaults to the current directory.
+**Note:** If changing the build context, ensure that the `dockerfile` parameter described below is also adjusted to be prefixed with the build context. For example if you have `docker-build-context: ./tignis/app`, then you'll also likely set `dockerfile: ./tignis/app/Dockerfile` too.
 
-`dockerfile`: The name of the Dockerfile to use. Default to `Dockerfile`.
-**Note:**: This path is always from the root of the repository, not from the root of the build-context.
+`dockerfile`: The name of the Dockerfile to use. Defaults to `Dockerfile`.
+**Note:** This path is always from the root of the repository, not from the root of the build-context.
 
 `platforms`: A comma separated list of platforms to build images for. Defaults to `linux/amd64,linux/arm64`.
 
 `tag-prefix`: A prefix to add to the generated image tag. Defaults to an empty string.
 
+### Workflow Inputs (Option 2)
+
+The reusable workflow accepts similar inputs but through the `with:` section:
+
+- `images`: Container image name (required)
+- `acr-registry-url`: Registry URL (optional, defaults to `tignis.azurecr.io`)
+- `push`: Whether to push images (optional, defaults to `true`)
+- `docker-build-context`: Build context directory (optional, defaults to `.`)
+- `dockerfile`: Dockerfile name (optional, defaults to `Dockerfile`)
+
 ## Outputs
 
+### Action Outputs (Option 1)
+
 `tag`: The image tag that was generated.
+
+### Workflow Outputs (Option 2)
+
+`tag`: The final multi-architecture manifest tag that was created.
+
+## Self-Hosted Runner Requirements
+
+For the multi-architecture workflow to work properly, you need:
+
+- Self-hosted runner with `[self-hosted, linux, ARM64]` labels
+- Docker installed and configured on the ARM64 runner
+- Access to your container registry from the self-hosted runner
+
+## Migration Guide
+
+To migrate from the single action to the multi-architecture workflow:
+
+1. Replace the `steps:` section with a `uses:` reference to the workflow
+2. Move your parameters from `with:` (action) to `with:` (workflow) 
+3. Move secrets from `with:` to the `secrets:` section
+4. Add `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to secrets
+5. Add required permissions to your workflow file
+6. Ensure you have ARM64 self-hosted runners available
+
+The multi-architecture workflow is recommended for production applications that need to support both AMD64 and ARM64 platforms.

--- a/README.md
+++ b/README.md
@@ -4,40 +4,7 @@ GitHub action wrapping a typical Docker build for a Tignis app. This workflow as
 
 ## Usage Options
 
-### Option 1: Single Action (Simple)
-
-Use the action directly for single-platform builds or when you don't need separate architecture builds:
-
-```yaml
-name: ci
-
-on:
-  push:
-    branches:
-      - 'main'
-  pull_request:
-    branches:
-      - 'main'
-  release:
-    types: [created]
-
-jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Push docker image
-        uses: tignis/docker-github-action@v2.3.1
-        with:
-          images: |
-            tignis.azurecr.io/tignis/my_app
-          acr-username: ${{ secrets.AZURE_APP_ID_ACR }}
-          acr-password: ${{ secrets.AZURE_PASSWORD_ACR }}
-          pip-extra-index-url: ${{ secrets.PIP_EXTRA_INDEX_URL }}
-```
-
-### Option 2: Multi-Architecture Workflow (Recommended)
+### Option 1: Multi-Architecture Workflow (Recommended)
 
 Use the reusable workflow for multi-architecture builds with dedicated runners for each architecture:
 
@@ -61,27 +28,11 @@ on:
     types: [created]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Install package
-        env:
-          PIP_EXTRA_INDEX_URL: ${{ secrets.PIP_EXTRA_INDEX_URL }}
-        run: |
-          python -m pip install --upgrade pip setuptools
-          pip install '.[testing]'
-      - name: Test with pytest
-        run: pytest
 
   docker:
     needs:
       - build  # Optional: depend on tests passing first
-    uses: tignis/docker-github-action/.github/workflows/workflows.yaml@v2.3.1
+    uses: tignis/docker-github-action/.github/workflows/workflows.yaml@v2.3.2
     with:
       images: tignis.azurecr.io/tignis/my_app
     secrets:
@@ -90,6 +41,40 @@ jobs:
       pip-extra-index-url: ${{ secrets.PIP_EXTRA_INDEX_URL }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Option 2: Single Action (Simple)
+
+Use the action directly for single-platform builds or when you don't need separate architecture builds:
+
+```yaml
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+  release:
+    types: [created]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and Push docker image
+        uses: tignis/docker-github-action@v2.3.2
+        with:
+          images: |
+            tignis.azurecr.io/tignis/my_app
+          acr-username: ${{ secrets.AZURE_APP_ID_ACR }}
+          acr-password: ${{ secrets.AZURE_PASSWORD_ACR }}
+          pip-extra-index-url: ${{ secrets.PIP_EXTRA_INDEX_URL }}
+```
+
 
 ## Multi-Architecture Workflow Features
 


### PR DESCRIPTION
Here is the new reusable workflow for our github actions.
It spins up two parallel jobs for building amd64 and arm64 images. Thank you @mhaley-tignis for the idea.

I see that `async-event-service` builds in approx 2 mins for amd64 and arm64.

I added a how to use/migrate section in the readme.
You can also find an example usage on 
https://github.com/tignis/async-event-service/pull/46

If you notice in the PR that github says "Waiting for status report from docker" you should ask the repo owner to remove this condition from the branch protection rules.

Everything else works as it used to.